### PR TITLE
Handle camera permissions

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -37,5 +37,13 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+        ## dart: PermissionGroup.camera
+        'PERMISSION_CAMERA=0',
+        ## dart: PermissionGroup.photos
+        'PERMISSION_PHOTOS=1'
+      ]
+    end
   end
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -7,6 +7,8 @@ PODS:
     - TOCropViewController (~> 2.6.1)
   - path_provider_ios (0.0.1):
     - Flutter
+  - permission_handler_apple (9.0.4):
+    - Flutter
   - TOCropViewController (2.6.1)
 
 DEPENDENCIES:
@@ -14,6 +16,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
+  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
 
 SPEC REPOS:
   trunk:
@@ -28,14 +31,17 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_cropper/ios"
   path_provider_ios:
     :path: ".symlinks/plugins/path_provider_ios/ios"
+  permission_handler_apple:
+    :path: ".symlinks/plugins/permission_handler_apple/ios"
 
 SPEC CHECKSUMS:
   camera_avfoundation: 07c77549ea54ad95d8581be86617c094a46280d9
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   image_cropper: 60c2789d1f1a78c873235d4319ca0c34a69f2d98
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
+  permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
 
-PODFILE CHECKSUM: 57c8aed26fba39d3ec9424816221f294a07c58eb
+PODFILE CHECKSUM: 8f47a27b10ca7e4cff0ebe6130039de72be6bc85
 
 COCOAPODS: 1.11.3

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -24,6 +24,10 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>App needs access to photo lib for profile images</string>
+	<key>NSCameraUsageDescription</key>
+	<string>To capture profile photo please grant camera access</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/lib/image_upload_screen.dart
+++ b/lib/image_upload_screen.dart
@@ -21,22 +21,16 @@ class _ImageUploadScreenState extends State<ImageUploadScreen> {
 
   // button function to set to display Camera Screen
   void toCameraScreen() async {
-    await getCameraPerms().then(
-      (permStatus) async {
-        if (permStatus.isGranted) {
-          await availableCameras().then(
-            (cameras) {
-              Navigator.push(
-                context, 
-                MaterialPageRoute(
-                  builder: (context) => CameraScreen(cameras: cameras)
-                )
-              );
-            }
-          );
-        }
+    await getCameraPerms().then((permStatus) async {
+      if (permStatus.isGranted) {
+        await availableCameras().then((cameras) {
+          Navigator.push(
+              context,
+              MaterialPageRoute(
+                  builder: (context) => CameraScreen(cameras: cameras)));
+        });
       }
-    );
+    });
   }
 
   void toCameraRollScreen() {
@@ -47,7 +41,6 @@ class _ImageUploadScreenState extends State<ImageUploadScreen> {
 
   Future<PermissionStatus> getCameraPerms() async {
     PermissionStatus cameraPermStatus = await Permission.camera.request();
-
     if (!cameraPermStatus.isGranted) {
       showCameraPermsAlert();
     }
@@ -57,32 +50,29 @@ class _ImageUploadScreenState extends State<ImageUploadScreen> {
 
   Future<void> showCameraPermsAlert() async {
     return showDialog<void>(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text("Camera Access Denied"),
-          content: const SingleChildScrollView(
-            child: Text("Enable camera to continue."),
-          ),
-          actions: <Widget>[
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text("Cancel"),
-            ),
-            TextButton(
-              onPressed: () {
-                openAppSettings();
-                Navigator.pop(context);
-              },
-              child: const Text("Settings"),
-            ),
-          ]
-        );
-      }
-    );
+        context: context,
+        barrierDismissible: false,
+        builder: (BuildContext context) {
+          return AlertDialog(
+              title: const Text("Camera Access Denied"),
+              content: const SingleChildScrollView(
+                child: Text("Enable camera to continue."),
+              ),
+              actions: <Widget>[
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text("Cancel"),
+                ),
+                TextButton(
+                  onPressed: () {
+                    openAppSettings();
+                    Navigator.pop(context);
+                  },
+                  child: const Text("Settings"),
+                ),
+              ]);
+        });
   }
-
 }
 
 class _ImageUploadScreenView extends StatelessWidget {
@@ -93,22 +83,21 @@ class _ImageUploadScreenView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Container(
+        body: Container(
       margin: const EdgeInsets.symmetric(vertical: 35.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
           Stack(
-            alignment: Alignment.center, 
+            alignment: Alignment.center,
             children: const [
               Positioned(left: 10, child: BackButton()),
               Align(
-                child: Text(
-                  "Choose Analysis Type",
-                  textAlign: TextAlign.center,
-                  textScaleFactor: 1.5,
-                )
-              ),
+                  child: Text(
+                "Choose Analysis Type",
+                textAlign: TextAlign.center,
+                textScaleFactor: 1.5,
+              )),
             ],
           ),
           Expanded(
@@ -120,9 +109,8 @@ class _ImageUploadScreenView extends StatelessWidget {
                   pressFunction: state.toCameraScreen,
                 ),
                 ScreenButton(
-                  buttonText: "From Camera Roll",
-                  pressFunction: state.toCameraRollScreen
-                ),
+                    buttonText: "From Camera Roll",
+                    pressFunction: state.toCameraRollScreen),
                 ScreenButton(
                   buttonText: "From Files",
                   pressFunction: () {

--- a/lib/image_upload_screen.dart
+++ b/lib/image_upload_screen.dart
@@ -15,6 +15,38 @@ class ImageUploadScreen extends StatefulWidget {
 
 class _ImageUploadScreenState extends State<ImageUploadScreen> {
   @override
+  Widget build(BuildContext context) => _ImageUploadScreenView(state: this);
+
+  // button function to set to display Camera Screen
+  void toCameraScreen() async {
+    try {
+      await availableCameras().then((cameras) {
+          Navigator.push(
+          context, 
+          MaterialPageRoute(
+            builder: (context) => CameraScreen(cameras: cameras)
+          )
+        );
+      });
+    } on CameraException catch (e) {
+      print("Camera Exception: $e");
+    }
+  }
+
+  void toCameraRollScreen() {
+    print("Camera Roll");
+    //Code to navigate to next screen goes here
+    //might look like navigator.push(context, static id of next screen when its made
+  }
+
+}
+
+class _ImageUploadScreenView extends StatelessWidget {
+  const _ImageUploadScreenView({super.key, required this.state});
+
+  final _ImageUploadScreenState state;
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Container(
@@ -41,35 +73,24 @@ class _ImageUploadScreenState extends State<ImageUploadScreen> {
               children: <Widget>[
                 ScreenButton(
                   buttonText: "From Camera",
-                  pressFunction: () {
-                    print("Camera");
-                    toCameraScreen();
-                    //Code to navigate to next screen goes here
-                    //might look like navigator.push(context, static id of next screen when its made
-                  },
+                  pressFunction: state.toCameraScreen,
                 ),
                 ScreenButton(
                   buttonText: "From Camera Roll",
-                  pressFunction: () {
-                    print("Camera Roll");
-                    //Code to navigate to next screen goes here
-                    //might look like navigator.push(context, static id of next screen when its made
-                  },
+                  pressFunction: state.toCameraRollScreen
                 ),
                 ScreenButton(
                   buttonText: "From Files",
                   pressFunction: () {
                     print("Files");
-                    //Code to navigate to next screen goes here
-                    //might look like navigator.push(context, static id of next screen when its made
+                    // Implementation TBD
                   },
                 ),
                 ScreenButton(
                   buttonText: "From Google Drive",
                   pressFunction: () {
                     print("Google Drive");
-                    //Code to navigate to next screen goes here
-                    //might look like navigator.push(context, static id of next screen when its made
+                    // Implementation TBD
                   },
                 ),
               ],
@@ -78,21 +99,5 @@ class _ImageUploadScreenState extends State<ImageUploadScreen> {
         ],
       ),
     ));
-  }
-
-  // button function to set to display Camera Screen
-  void toCameraScreen() async {
-    try {
-      await availableCameras().then((cameras) {
-          Navigator.push(
-          context, 
-          MaterialPageRoute(
-            builder: (context) => CameraScreen(cameras: cameras)
-          )
-        );
-      });
-    } on CameraException catch (e) {
-      print(e);
-    }
   }
 }

--- a/lib/image_upload_screen.dart
+++ b/lib/image_upload_screen.dart
@@ -3,6 +3,8 @@ import 'screen_button.dart';
 import "package:camera/camera.dart";
 import "camera_screen.dart";
 
+import 'package:permission_handler/permission_handler.dart';
+
 class ImageUploadScreen extends StatefulWidget {
   const ImageUploadScreen({Key? key}) : super(key: key);
 
@@ -19,24 +21,66 @@ class _ImageUploadScreenState extends State<ImageUploadScreen> {
 
   // button function to set to display Camera Screen
   void toCameraScreen() async {
-    try {
-      await availableCameras().then((cameras) {
-          Navigator.push(
-          context, 
-          MaterialPageRoute(
-            builder: (context) => CameraScreen(cameras: cameras)
-          )
-        );
-      });
-    } on CameraException catch (e) {
-      print("Camera Exception: $e");
-    }
+    await getCameraPerms().then(
+      (permStatus) async {
+        if (permStatus.isGranted) {
+          await availableCameras().then(
+            (cameras) {
+              Navigator.push(
+                context, 
+                MaterialPageRoute(
+                  builder: (context) => CameraScreen(cameras: cameras)
+                )
+              );
+            }
+          );
+        }
+      }
+    );
   }
 
   void toCameraRollScreen() {
     print("Camera Roll");
     //Code to navigate to next screen goes here
     //might look like navigator.push(context, static id of next screen when its made
+  }
+
+  Future<PermissionStatus> getCameraPerms() async {
+    PermissionStatus cameraPermStatus = await Permission.camera.request();
+
+    if (!cameraPermStatus.isGranted) {
+      showCameraPermsAlert();
+    }
+
+    return cameraPermStatus;
+  }
+
+  Future<void> showCameraPermsAlert() async {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text("Camera Access Denied"),
+          content: const SingleChildScrollView(
+            child: Text("Enable camera to continue."),
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text("Cancel"),
+            ),
+            TextButton(
+              onPressed: () {
+                openAppSettings();
+                Navigator.pop(context);
+              },
+              child: const Text("Settings"),
+            ),
+          ]
+        );
+      }
+    );
   }
 
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -275,6 +275,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "10.0.2"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "10.0.0"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "9.0.4"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.7.1"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   image_cropper: ^3.0.0
   path_provider: ^2.0.11
   path: ^1.8.2
+  permission_handler: ^10.0.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Added handling of camera permissions in the image upload screen.

When a user tries to access the camera without giving device permissions, they are alerted by a popup and prompted to provide camera access through the device's settings.

Only implemented for camera permissions, not camera roll/storage.

Will also need to verify that this works for iOS, and not just Android.