### PR TITLE
Calculate front measurements initial

### DIFF
--- a/lib/drag_screen.dart
+++ b/lib/drag_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import "dragable.dart";
 import 'dart:math';
 import 'package:image_pixels/image_pixels.dart';
+import 'image_handler.dart';
 import "coordinate.dart";
 /*
 How this scruffed ass proof of concept even works
@@ -31,6 +32,8 @@ class DragScreen extends StatefulWidget {
 class _DragScreenState extends State<DragScreen> {
   @override
   Widget build(BuildContext context) => _DragScreenView(state: this);
+
+  ImageHandler imageHandler = ImageHandler();
 
   //REFERENCE TO DRAGGABLE WIDGET
   late Drag_Button draggableOne;
@@ -120,15 +123,27 @@ class _DragScreenState extends State<DragScreen> {
     heightOfDraggable = imgContainerHeight * 0.027;
     widthOfDraggable = imgContainerWidth * 0.065;
 
+    //This function call sets the scalars that allow us to go from the image file's resolution to the screen resolution and back
+    setScreenRatios(img.width!, img.height!);
+
     //This is a temporary line to create a point that would normally be held in image handler when we get there
     //This point is calculated to be in the middle of the image file in its native resolution
     //This is also used to determine where the dragable initially spawns. We use math to convert where the point is in
     //the native image resolution to figure out where the dragable should roughly be in screen resolution
-    firstPointInImageResolution = Coordinate(x: img.width! / 2, y: img.height! / 2);
-    secondPointInImageResolution = Coordinate(x: firstPointInImageResolution.x + 50, y: firstPointInImageResolution.y + 50);
 
-    //This function call sets the scalars that allow us to go from the image file's resolution to the screen resolution and back
-    setScreenRatios(img.width!, img.height!);
+    if (imageHandler.isFrontImage) {
+      // Point 1 = Radial Styloid (Front)
+      firstPointInImageResolution = Coordinate(x: imageHandler.getRadialStyloidX() * screenToCameraRatioX, y: imageHandler.getRadialStyloidY() * screenToCameraRatioY);
+      // Point 2 = Min Articular Surface (Front)
+      secondPointInImageResolution = Coordinate(x: imageHandler.getMinArticularSurfaceX() * screenToCameraRatioX, y: imageHandler.getMinArticularSurfaceY() * screenToCameraRatioY);
+    } else {
+      // Point 1 in Side Image
+      firstPointInImageResolution = Coordinate(x: img.width! / 2, y: img.height! / 2);
+      // Point 2 in Side Image
+      secondPointInImageResolution = Coordinate(x: firstPointInImageResolution.x + 50, y: firstPointInImageResolution.y + 50);
+    } 
+    
+
 
     draggableOne = Drag_Button(
         startDragFunction: firstDragableStartCallback,

--- a/lib/drag_screen.dart
+++ b/lib/drag_screen.dart
@@ -143,8 +143,6 @@ class _DragScreenState extends State<DragScreen> {
       secondPointInImageResolution = Coordinate(x: firstPointInImageResolution.x + 50, y: firstPointInImageResolution.y + 50);
     } 
     
-
-
     draggableOne = Drag_Button(
         startDragFunction: firstDragableStartCallback,
         pressFunction: firstDragableUpdateCallback,

--- a/lib/image_handler.dart
+++ b/lib/image_handler.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 
 // singleton Image Handler class
 class ImageHandler {
@@ -14,7 +15,15 @@ class ImageHandler {
   // a number tag to add at the end of file paths/names so that
   // new images can be saved (if user retakes an image)
   int fileID = 0;
- 
+
+  // coordinates of Radial Styloid (in Pixels) (set to random default values for now)
+  late double radialStyloidX = 100;
+  late double radialStyloidY = 200;
+
+  // coordinates of minArticularSurface (in Pixels) (set to random default values for now)
+  late double minArticularSurfaceX = 300;
+  late double minArticularSurfaceY = 400;
+
   factory ImageHandler() {
     return _instance;
   }
@@ -25,6 +34,57 @@ class ImageHandler {
     String newFileID = fileID.toString();
     fileID++;
     return newFileID;
+  }
+
+  // Set coordinates of key points.
+  void setRadialStyloid(double x, double y) {
+    radialStyloidX = x;
+    radialStyloidY = y;
+  }
+
+  void setMinArticularSurface(double x, double y) {
+    minArticularSurfaceX = x;
+    minArticularSurfaceY = y;
+  }
+
+  double getMinArticularSurfaceX() {
+    return minArticularSurfaceX;
+  }
+
+  double getMinArticularSurfaceY() {
+    return minArticularSurfaceY;
+  }
+
+  double getRadialStyloidX() {
+    return radialStyloidX;
+  }
+
+  double getRadialStyloidY() {
+    return radialStyloidY;
+  }
+
+  // calculates Radial Inclucnation (angle of inclination) in DEGREES
+  double getRadialInclination() {
+    if (isMissingPoints()) {
+      print("Missing Point Coords");
+      return 0;
+    } else {
+      print(atan(radialStyloidY / radialStyloidX));
+      return atan(radialStyloidY / radialStyloidX) * 180 / pi;
+    }
+  }
+
+  double getRadialHeight() {
+    if (isMissingPoints()) {
+      print("Missing Point Coords");
+      return 0;
+    } else {
+      return minArticularSurfaceY - radialStyloidY;
+    }
+  }
+
+  bool isMissingPoints() {
+    return radialStyloidX == null || radialStyloidY == null || minArticularSurfaceX == null || minArticularSurfaceY == null;
   }
 
   // basic getters/setters

--- a/lib/image_handler.dart
+++ b/lib/image_handler.dart
@@ -63,17 +63,17 @@ class ImageHandler {
     return radialStyloidY;
   }
 
-  // calculates Radial Inclucnation (angle of inclination) in DEGREES
+  // calculates Radial Inclination (angle of inclination) in DEGREES
   double getRadialInclination() {
     if (isMissingPoints()) {
       print("Missing Point Coords");
       return 0;
     } else {
-      print(atan(radialStyloidY / radialStyloidX));
       return atan(radialStyloidY / radialStyloidX) * 180 / pi;
     }
   }
 
+  // calcualtes Radial Height - currently still in pixels, not converted to IRL measurements
   double getRadialHeight() {
     if (isMissingPoints()) {
       print("Missing Point Coords");

--- a/lib/image_results_screen.dart
+++ b/lib/image_results_screen.dart
@@ -47,8 +47,11 @@ class _ImageResultsScreen extends State<ImageResultsScreen> {
   }
 
   Widget getImageInfo() {
-    final screenWidth = 0.9 * MediaQuery.of(context).size.width;
-    final screenHeight = 0.7 * MediaQuery.of(context).size.height;
+    final screenWidth = MediaQuery.of(context).size.width;
+    final screenHeight = MediaQuery.of(context).size.height;
+
+    final displayWidth = screenWidth - 40;
+    final displayHeight = screenHeight - 220;
 
     var image;
     if (widget.isFrontImage)
@@ -58,15 +61,17 @@ class _ImageResultsScreen extends State<ImageResultsScreen> {
 
     return ConstrainedBox(
         constraints: BoxConstraints(
-          maxWidth: screenWidth,
-          maxHeight: screenHeight,
+          minWidth: displayWidth,
+          maxWidth: displayWidth,
+          minHeight: displayHeight,
+          maxHeight: displayHeight,
         ),
         child: Stack(
           alignment: Alignment.center,
           children: [
             Image(image: image),
             CustomPaint(
-              size: Size(screenWidth, screenHeight),
+              size: Size(displayWidth, displayHeight),
               painter: ResultsPainter(),
             )
           ],
@@ -98,22 +103,50 @@ class _ImageResultsScreen extends State<ImageResultsScreen> {
 
 // Handles painting the circles and lines of the measurements
 class ResultsPainter extends CustomPainter {
+  ImageHandler imageHandler = ImageHandler();
+
   @override
   void paint(Canvas canvas, Size size) {
-    final p1 = Offset(10, 10);
-    final p2 = Offset(size.width - 20, size.height - 20);
+    final p1;
+    final p2;
+    final p1l;
+    final p1r;
+    final p2l; // reference point used to draw horizontal line
+    final p2r;
+    if (imageHandler.isFrontImage) {
+      p1 = Offset(imageHandler.getRadialStyloidX(), imageHandler.getRadialStyloidY());
+      p2 = Offset(imageHandler.getMinArticularSurfaceX(), imageHandler.getMinArticularSurfaceY());
 
-    final p3 = Offset(50, 50);
 
-    final paint = Paint()
+      p1l = Offset(0, imageHandler.getRadialStyloidY());
+      p1r = Offset(size.width, imageHandler.getRadialStyloidY());
+      p2l = Offset(0, imageHandler.getMinArticularSurfaceY());
+      p2r = Offset(size.width, imageHandler.getMinArticularSurfaceY());
+    } else {
+      // Side Image not yet Implemented
+      // random default values used
+      p1 = Offset(0, 0);
+      p2 = Offset(size.width - 20, size.height - 20);
+      p1l = Offset(0, 0);
+      p1r = Offset(size.width, 0);
+      p2l = Offset(0, size.height - 2);
+      p2r = Offset(size.width, size.height - 2);
+    }
+
+    final paintRed = Paint()
+      ..color = Colors.red
+      ..strokeWidth = 2;
+
+      final paintBlack = Paint()
       ..color = Colors.black
-      ..strokeWidth = 4;
+      ..strokeWidth = 2;
 
-    canvas.drawLine(p1, p2, paint);
+    canvas.drawLine(p1, p2, paintRed);
+    canvas.drawLine(p1l, p1r, paintRed);
+    canvas.drawLine(p2l, p2r, paintRed);
 
-    canvas.drawCircle(p1, 10, paint);
-    canvas.drawCircle(p2, 10, paint);
-    canvas.drawCircle(p3, 10, paint);
+    canvas.drawCircle(p1, 8, paintBlack);
+    canvas.drawCircle(p2, 8, paintBlack);
   }
 
   @override

--- a/lib/results_edit_screen.dart
+++ b/lib/results_edit_screen.dart
@@ -36,7 +36,7 @@ class _ResultsEditScreenState extends State<ResultsEditScreen> {
     Navigator.of(context).pop();
   }
 
-    void confirmEdit() {
+  void confirmEdit() {
     // save edited measurement poiunts and return to results screen
     print("Confirm Edit");
   }

--- a/lib/results_screen.dart
+++ b/lib/results_screen.dart
@@ -29,6 +29,7 @@ class _ResultsScreenState extends State<ResultsScreen> {
   }
 
   void toImageResults(isFront) {
+    imageHandler.isFrontImage = isFront;
     Navigator.push(
         context,
         MaterialPageRoute(
@@ -76,18 +77,26 @@ class _ResultsScreenState extends State<ResultsScreen> {
   }
 
   Widget getResultsInfo() {
+    double volarTilt = 1.0;
+    double radialHeight = imageHandler.getRadialHeight();
+    double radialInclination = imageHandler.getRadialInclination();
+
     return Container(
         margin: EdgeInsets.symmetric(vertical: 0.0, horizontal: 30.0),
         child: Column(children: [
-          getResultValue("Volar Tilt", 1.0, 0.5, 1.5),
+          getResultValue("Volar Tilt", volarTilt, 0.5, 1.5),
           SizedBox(height: 20),
-          getResultValue("Radial Height", 0.3, 0.5, 1.5),
+          getResultValue("Radial Height", radialHeight, 0.5, 1.5),
           SizedBox(height: 20),
-          getResultValue("Radial Inclination", 0.0, 2.0, 3.5)
+          getResultValue("Radial Inclination", radialInclination, 2.0, 3.5)
         ]));
   }
 
   Column getResultValue(String title, double value, double min, double max) {
+
+    // parses a double as a string rounded to 1 decimal place
+    String valueString = value.toStringAsFixed(1);
+
     Color color;
 
     double difference = (value - min).abs();
@@ -112,7 +121,7 @@ class _ResultsScreenState extends State<ResultsScreen> {
                 borderRadius: BorderRadius.circular(15.0)),
             child: Row(
               children: [
-                Text(value.toString(), style: TextStyle(color: color)),
+                Text(valueString, style: TextStyle(color: color)),
                 Spacer(),
                 Text(rangeText, style: TextStyle(color: Colors.green))
               ],


### PR DESCRIPTION
Updated Image Handler to store pixel coordinates of the 2 key points. Also added methods to calculate the relevant measurement values.

NOTE: only points and measurements for the Frontal Image have been implemented. 

Also updated the results screen, image results screen, and drag screen. 
The results screen now displayed the measurement values calculated from the Image Handler. 
The image results screen gets its point coordinates from the Image Handler and correctly draws the corresponding guidelines. 
The drag screen now initialized its draggable locations based on the points from the Image Handler.

No other functionality was changed on these screens. 
