### PR TITLE
implement display of points on frontal and lateral view

### DIFF
--- a/lib/drag_screen.dart
+++ b/lib/drag_screen.dart
@@ -133,14 +133,14 @@ class _DragScreenState extends State<DragScreen> {
 
     if (imageHandler.isFrontImage) {
       // Point 1 = Radial Styloid (Front)
-      firstPointInImageResolution = Coordinate(x: imageHandler.getRadialStyloidX() * screenToCameraRatioX, y: imageHandler.getRadialStyloidY() * screenToCameraRatioY);
+      firstPointInImageResolution = Coordinate(x: imageHandler.getRadialStyloidFrontX() * screenToCameraRatioX, y: imageHandler.getRadialStyloidFrontY() * screenToCameraRatioY);
       // Point 2 = Min Articular Surface (Front)
       secondPointInImageResolution = Coordinate(x: imageHandler.getMinArticularSurfaceX() * screenToCameraRatioX, y: imageHandler.getMinArticularSurfaceY() * screenToCameraRatioY);
     } else {
       // Point 1 in Side Image
-      firstPointInImageResolution = Coordinate(x: img.width! / 2, y: img.height! / 2);
+      firstPointInImageResolution = Coordinate(x: imageHandler.getLateralUpperX() * screenToCameraRatioX, y: imageHandler.getLateralUpperY() * screenToCameraRatioY);
       // Point 2 in Side Image
-      secondPointInImageResolution = Coordinate(x: firstPointInImageResolution.x + 50, y: firstPointInImageResolution.y + 50);
+      secondPointInImageResolution = Coordinate(x: imageHandler.getLateralLowerX() * screenToCameraRatioX, y: imageHandler.getLateralLowerY() * screenToCameraRatioY);
     } 
     
     draggableOne = Drag_Button(

--- a/lib/image_handler.dart
+++ b/lib/image_handler.dart
@@ -17,12 +17,22 @@ class ImageHandler {
   int fileID = 0;
 
   // coordinates of Radial Styloid (in Pixels) (set to random default values for now)
-  late double radialStyloidX = 100;
-  late double radialStyloidY = 200;
+  late double RadialStyloidFrontX = 100;
+  late double RadialStyloidFrontY = 200;
 
   // coordinates of minArticularSurface (in Pixels) (set to random default values for now)
   late double minArticularSurfaceX = 300;
   late double minArticularSurfaceY = 400;
+
+  // TODO：update variable names to reflect actual names for lateral projection
+
+  // coordinates of upper point in Lateral projection (in Pixels) (set to random default values for now)
+  late double lateralUpperX = 100;
+  late double lateralUpperY = 200;
+
+  // coordinates of lower point in Lateral projection (in Pixels) (set to random default values for now)
+  late double lateralLowerX = 300;
+  late double lateralLowerY = 400;
 
   factory ImageHandler() {
     return _instance;
@@ -37,9 +47,9 @@ class ImageHandler {
   }
 
   // Set coordinates of key points.
-  void setRadialStyloid(double x, double y) {
-    radialStyloidX = x;
-    radialStyloidY = y;
+  void setRadialStyloidFront(double x, double y) {
+    RadialStyloidFrontX = x;
+    RadialStyloidFrontY = y;
   }
 
   void setMinArticularSurface(double x, double y) {
@@ -47,6 +57,17 @@ class ImageHandler {
     minArticularSurfaceY = y;
   }
 
+  void setlateralUpper(double x, double y) {
+    lateralUpperX = x;
+    lateralUpperY = y;
+  }
+
+  void setlateralLower(double x, double y) {
+    lateralLowerX = x;
+    lateralLowerY = y;
+  }
+
+  // getters for coords of key poits
   double getMinArticularSurfaceX() {
     return minArticularSurfaceX;
   }
@@ -55,12 +76,28 @@ class ImageHandler {
     return minArticularSurfaceY;
   }
 
-  double getRadialStyloidX() {
-    return radialStyloidX;
+  double getRadialStyloidFrontX() {
+    return RadialStyloidFrontX;
   }
 
-  double getRadialStyloidY() {
-    return radialStyloidY;
+  double getRadialStyloidFrontY() {
+    return RadialStyloidFrontY;
+  }
+
+  double getLateralUpperX() {
+    return lateralUpperX;
+  }
+
+  double getLateralUpperY() {
+    return lateralUpperY;
+  }
+
+  double getLateralLowerX() {
+    return lateralLowerX;
+  }
+
+  double getLateralLowerY() {
+    return lateralLowerY;
   }
 
   // calculates Radial Inclination (angle of inclination) in DEGREES
@@ -69,7 +106,7 @@ class ImageHandler {
       print("Missing Point Coords");
       return 0;
     } else {
-      return atan(radialStyloidY / radialStyloidX) * 180 / pi;
+      return atan(RadialStyloidFrontY / RadialStyloidFrontX) * 180 / pi;
     }
   }
 
@@ -79,12 +116,12 @@ class ImageHandler {
       print("Missing Point Coords");
       return 0;
     } else {
-      return minArticularSurfaceY - radialStyloidY;
+      return minArticularSurfaceY - RadialStyloidFrontY;
     }
   }
 
   bool isMissingPoints() {
-    return radialStyloidX == null || radialStyloidY == null || minArticularSurfaceX == null || minArticularSurfaceY == null;
+    return RadialStyloidFrontX == null || RadialStyloidFrontY == null || minArticularSurfaceX == null || minArticularSurfaceY == null;
   }
 
   // basic getters/setters

--- a/lib/image_results_screen.dart
+++ b/lib/image_results_screen.dart
@@ -1,6 +1,7 @@
 import 'package:distal_radius/image_handler.dart';
 import 'package:flutter/material.dart';
 import 'results_edit_screen.dart';
+import "screen_button.dart";
 
 import 'dart:io';
 
@@ -82,9 +83,10 @@ class _ImageResultsScreen extends State<ImageResultsScreen> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
-        ElevatedButton(
-          child: const Text('Edit Image'),
-          onPressed: toEditImage,
+        ScreenButton(
+          buttonText: "Edit Points",
+          pressFunction: toEditImage,
+          width: 200,
         ),
       ],
     );
@@ -114,23 +116,21 @@ class ResultsPainter extends CustomPainter {
     final p2l; // reference point used to draw horizontal line
     final p2r;
     if (imageHandler.isFrontImage) {
-      p1 = Offset(imageHandler.getRadialStyloidX(), imageHandler.getRadialStyloidY());
+      p1 = Offset(imageHandler.getRadialStyloidFrontX(), imageHandler.getRadialStyloidFrontY());
       p2 = Offset(imageHandler.getMinArticularSurfaceX(), imageHandler.getMinArticularSurfaceY());
 
-
-      p1l = Offset(0, imageHandler.getRadialStyloidY());
-      p1r = Offset(size.width, imageHandler.getRadialStyloidY());
+      p1l = Offset(0, imageHandler.getRadialStyloidFrontY());
+      p1r = Offset(size.width, imageHandler.getRadialStyloidFrontY());
       p2l = Offset(0, imageHandler.getMinArticularSurfaceY());
       p2r = Offset(size.width, imageHandler.getMinArticularSurfaceY());
     } else {
-      // Side Image not yet Implemented
-      // random default values used
-      p1 = Offset(0, 0);
-      p2 = Offset(size.width - 20, size.height - 20);
-      p1l = Offset(0, 0);
-      p1r = Offset(size.width, 0);
-      p2l = Offset(0, size.height - 2);
-      p2r = Offset(size.width, size.height - 2);
+      p1 = Offset(imageHandler.getLateralUpperX(), imageHandler.getLateralUpperY());
+      p2 = Offset(imageHandler.getLateralLowerX(), imageHandler.getLateralLowerY());
+
+      p1l = Offset(0, imageHandler.getLateralUpperY());
+      p1r = Offset(size.width, imageHandler.getLateralUpperY());
+      p2l = Offset(0, imageHandler.getLateralLowerY());
+      p2r = Offset(size.width, imageHandler.getLateralLowerY());
     }
 
     final paintRed = Paint()

--- a/lib/screenshot_handler.dart
+++ b/lib/screenshot_handler.dart
@@ -1,3 +1,2 @@
 class ScreenshotHandler {
-  static final ScreenshotHandler _instance = ScreenshotHandler._internal();
 }


### PR DESCRIPTION
Add storage of 4 points in Image Handler (2 in Frontal Image, 2 in Lateral Image). Also updated the results screen/results image screen and the drag and drop screen to display the corresponding points from the Image Handler.

Also updated button appearance in the results image screen.