### PR TITLE
revert save popup to return to home screen

### DIFF
--- a/lib/export_screen.dart
+++ b/lib/export_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:distal_radius/screenshot_handler.dart';
-import 'package:distal_radius/results_screen.dart';
+import 'package:distal_radius/welcome_screen.dart';
 import 'screen_button.dart';
 
 import 'package:permission_handler/permission_handler.dart';
@@ -28,8 +28,8 @@ class _ExportScreenState extends State<ExportScreen> {
     print("Send through email");
   }
 
-  void returnToResults() {
-    Navigator.of(context).popUntil(ModalRoute.withName(ResultsScreen.id));
+  void returnToHome() {
+    Navigator.of(context).popUntil(ModalRoute.withName(WelcomeScreen.id));
   }
 
   void toSaveCameraRollScreen() async {
@@ -58,13 +58,13 @@ class _ExportScreenState extends State<ExportScreen> {
               actions: <Widget>[
                 TextButton(
                   onPressed: () => Navigator.pop(context),
-                  child: const Text("Cancel"),
+                  child: const Text("Done"),
                 ),
                 TextButton(
                   onPressed: () {
-                    returnToResults();
+                    returnToHome();
                   },
-                  child: const Text("To Results"),
+                  child: const Text("To Home"),
                 )
               ]);
         });


### PR DESCRIPTION
The popup after successfully saving the images to the camera roll crashed the app when returning to the results screen. I went ahead and reverted the popup to send the user back to the home screen. 

I changed the wording so that it is clearer that the user can stay in the current analysis by clicking "Done" instead of "Cancel"