### PR TITLE
Update modified measurements

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 33
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/lib/drag_screen.dart
+++ b/lib/drag_screen.dart
@@ -17,10 +17,14 @@ Still have to draw lines between squares on the screen
    //TODO: Make a class that contains the callback functions that can be used for both buttons rather than having a bunch of diff callbacks
 */
 
+typedef PointUpdateCallback = void Function(double, double, double, double);
+
 class DragScreen extends StatefulWidget {
   final String passedImagePath;
 
-  const DragScreen({super.key, required this.passedImagePath});
+  final PointUpdateCallback updateFunction;
+
+  const DragScreen({super.key, required this.passedImagePath, required this.updateFunction});
 
   //const DragScreen({Key? key}) : super(key: key);
   static const String id = "drag_screen";
@@ -135,28 +139,30 @@ class _DragScreenState extends State<DragScreen> {
       // Point 1 = Radial Styloid (Front)
       firstPointInImageResolution = Coordinate(x: imageHandler.getRadialStyloidFrontX() * screenToCameraRatioX, y: imageHandler.getRadialStyloidFrontY() * screenToCameraRatioY);
       // Point 2 = Min Articular Surface (Front)
-      secondPointInImageResolution = Coordinate(x: imageHandler.getMinArticularSurfaceX() * screenToCameraRatioX - 10, y: imageHandler.getMinArticularSurfaceY() * screenToCameraRatioY - 10);
+      secondPointInImageResolution = Coordinate(x: imageHandler.getMinArticularSurfaceX() * screenToCameraRatioX, y: imageHandler.getMinArticularSurfaceY() * screenToCameraRatioY);
     } else {
       // Point 1 in Side Image
       firstPointInImageResolution = Coordinate(x: imageHandler.getLateralUpperX() * screenToCameraRatioX, y: imageHandler.getLateralUpperY() * screenToCameraRatioY);
       // Point 2 in Side Image
       secondPointInImageResolution = Coordinate(x: imageHandler.getLateralLowerX() * screenToCameraRatioX, y: imageHandler.getLateralLowerY() * screenToCameraRatioY);
     } 
+
+    widget.updateFunction(firstPointInImageResolution.x, firstPointInImageResolution.y, secondPointInImageResolution.x, secondPointInImageResolution.y);
     
     draggableOne = Drag_Button(
         startDragFunction: firstDragableStartCallback,
         pressFunction: firstDragableUpdateCallback,
         endDragFunction: firstDragableEndDragCallback,
-        leftPos: firstPointInImageResolution.x * cameraToScreenRatioX,
-        topPos: firstPointInImageResolution.y * cameraToScreenRatioY,
+        leftPos: firstPointInImageResolution.x * cameraToScreenRatioX - widthOfDraggable / 2,
+        topPos: firstPointInImageResolution.y * cameraToScreenRatioY - heightOfDraggable / 2,
         color: Colors.red);
 
     draggableTwo = Drag_Button(
         startDragFunction: secondDragableStartCallback,
         pressFunction: secondDragableUpdateCallback,
         endDragFunction: secondDragableEndDragCallback,
-        leftPos: secondPointInImageResolution.x * cameraToScreenRatioX,
-        topPos: secondPointInImageResolution.y * cameraToScreenRatioY,
+        leftPos: secondPointInImageResolution.x * cameraToScreenRatioX - widthOfDraggable / 2,
+        topPos: secondPointInImageResolution.y * cameraToScreenRatioY - heightOfDraggable / 2,
         color: Colors.blue);
 
     initialized = true;
@@ -190,7 +196,7 @@ class _DragScreenState extends State<DragScreen> {
       // min(container X or y - widthX or Y of the draggable it self, max(0 x and y, draggablelocation)
       double newTop = min(imgContainerHeight - heightOfDraggable / 2,
           max(-(heightOfDraggable / 2), draggableOne.getTop() + details.delta.dy));
-      double newLeft = min(imgContainerWidth - heightOfDraggable / 2,
+      double newLeft = min(imgContainerWidth - widthOfDraggable / 2,
           max(-(heightOfDraggable / 2), draggableOne.getLeft() + details.delta.dx));
 
       //update the draggable reference
@@ -229,6 +235,8 @@ Here the offset is calculted and used to update the coordinates in the native im
         "New first point in camera resolution: ${firstPointInImageResolution.x} ${firstPointInImageResolution.y}");
     //Set local offset varable back to 0 otherwise if u just click but dont drag, it will use same offset that was used in last
     //drag end despite not actually moving
+
+    widget.updateFunction(firstPointInImageResolution.x, firstPointInImageResolution.y, secondPointInImageResolution.x, secondPointInImageResolution.y);
   }
 
   //Will make code cleaner
@@ -281,6 +289,8 @@ Here the offset is calculted and used to update the coordinates in the native im
         "New second point in camera resolution: ${secondPointInImageResolution.x} ${secondPointInImageResolution.y}");
     //Set local offset varable back to 0 otherwise if u just click but dont drag, it will use same offset that was used in last
     //drag end despite not actually moving
+
+    widget.updateFunction(firstPointInImageResolution.x, firstPointInImageResolution.y, secondPointInImageResolution.x, secondPointInImageResolution.y);
   }
 }
 

--- a/lib/image_confirm_screen.dart
+++ b/lib/image_confirm_screen.dart
@@ -32,6 +32,9 @@ class _ImageConfirmScreen extends State<ImageConfirmScreen> {
 
   final double lineScreenLength = 150;
 
+  late double imageDisplayWidth;
+  late double imageDisplayHeight;
+
   void cancelImage() {
     Navigator.of(context).popUntil(ModalRoute.withName(ImageUploadScreen.id));
   }
@@ -90,16 +93,11 @@ class _ImageConfirmScreen extends State<ImageConfirmScreen> {
   }
 
   Widget getImage() {
-    final screenWidth = MediaQuery.of(context).size.width;
-    final screenHeight = MediaQuery.of(context).size.height;
-
-    final displayWidth = screenWidth - 80;
-    final displayHeight = displayWidth / 9 * 16;
-
+    setImageDisplayDims();
     return ConstrainedBox(
         constraints: BoxConstraints(
-          maxWidth: displayWidth,
-          maxHeight: displayHeight,
+          maxWidth: imageDisplayWidth,
+          maxHeight: imageDisplayHeight,
         ),
         child: Stack(
           alignment: Alignment.center,
@@ -119,6 +117,15 @@ class _ImageConfirmScreen extends State<ImageConfirmScreen> {
           ]
         ),
     );
+  }
+
+  void setImageDisplayDims() {
+    final screenWidth = MediaQuery.of(context).size.width;
+
+    imageDisplayWidth = screenWidth - 80;
+    imageDisplayHeight = imageDisplayWidth / 9 * 16;
+
+    imageHandler.setImageScreenDims(imageDisplayWidth, imageDisplayHeight);
   }
 
   Widget getHeader() {

--- a/lib/image_handler.dart
+++ b/lib/image_handler.dart
@@ -1,5 +1,5 @@
-
 import 'package:flutter/material.dart';
+import 'package:vector_math/vector_math.dart';
 import 'dart:math';
 import "dart:io";
 
@@ -45,6 +45,9 @@ class ImageHandler {
   // screen pixels / image pixels
   late double imageToScreenRatioFront;
   late double imageToScreenRatioLateral;
+
+  bool isSetImageToScreenRatio = false;
+
   // cm / screen pixels
   late double screenToCmRatio;
 
@@ -55,15 +58,19 @@ class ImageHandler {
   ImageHandler._internal();
 
   // only need set length scale for frontal image
+  // set in image_confirm screen
   void setInputScale(double? lineLength, double? lineScreenLength) {
     if (lineLength == null || lineScreenLength == null) {
       print("Input Lengths Failed to Parse");
       screenToCmRatio = 1;
       return;
     }
+    frontalLineLength = lineLength;
+    frontalLineScreenLength = lineScreenLength;
     screenToCmRatio = lineLength / lineScreenLength;
   }
 
+  // set in results_screen
   void setImageScreenDims(double width, double height) {
     imageDisplayWidth = width;
     imageDisplayHeight = height;
@@ -164,13 +171,15 @@ class ImageHandler {
     return lateralLowerY * imageToScreenRatioLateral;
   }
 
-  // calculates Radial Inclination (angle of inclination) in DEGREES
+  // calculates Radial Inclination in DEGREES
   double getRadialInclination() {
     if (isMissingPoints()) {
       print("Missing Point Coords");
       return 0;
     } else {
-      return atan(radialStyloidFrontY / radialStyloidFrontX) * 180 / pi;
+      Vector2 hVector = Vector2(radialStyloidFrontX - minArticularSurfaceX, 0);
+      Vector2 aVector = Vector2(radialStyloidFrontX - minArticularSurfaceX, radialStyloidFrontY - minArticularSurfaceY);
+      return hVector.angleTo(aVector) * 180 / pi;
     }
   }
 
@@ -180,17 +189,19 @@ class ImageHandler {
       print("Missing Point Coords");
       return 0;
     } else {
-      return minArticularSurfaceY - radialStyloidFrontY;
+      return (minArticularSurfaceY - radialStyloidFrontY) * imageToScreenRatioFront * screenToCmRatio;
     }
   }
 
-  // calculates Volar Tilt (angle of inclination) in DEGREES
+  // calculates Volar Tilt in DEGREES
   double getVolarTilt() {
     if (isMissingPoints()) {
       print("Missing Point Coords");
       return 0;
     } else {
-      return atan(lateralUpperY / lateralUpperX) * 180 / pi;
+      Vector2 hVector = Vector2(lateralUpperX - lateralLowerX, 0);
+      Vector2 aVector = Vector2(lateralUpperX - lateralLowerX, lateralUpperY - lateralLowerY);
+      return hVector.angleTo(aVector) * 180 / pi;
     }
   }
 

--- a/lib/image_results_screen.dart
+++ b/lib/image_results_screen.dart
@@ -28,8 +28,8 @@ class _ImageResultsScreen extends State<ImageResultsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final screenWidth = MediaQuery.of(context).size.width;
-    final screenHeight = MediaQuery.of(context).size.height;
+    final displayWidth = imageHandler.getImageDisplayWidth();
+    final displayHeight = imageHandler.getImageDisplayHeight();
 
     String? imagePath = widget.isFrontImage
         ? imageHandler.frontImagePath
@@ -43,7 +43,7 @@ class _ImageResultsScreen extends State<ImageResultsScreen> {
                 children: [
                   ResultsWidgets.getHeader(widget.isFrontImage),
                   ResultsWidgets.getImageInfo(
-                      screenWidth, screenHeight, imagePath),
+                      displayWidth, displayHeight, imagePath),
                   ResultsWidgets.getBottomButtons(toEditImage)
                 ])));
   }
@@ -73,24 +73,22 @@ class ResultsWidgets {
   }
 
   static Widget getImageInfo(width, height, imagePath) {
-    final displayWidth = width - 80;
-    final displayHeight = displayWidth / 9 * 16;
 
     var image = FileImage(File(imagePath));
 
     return ConstrainedBox(
         constraints: BoxConstraints(
-          minWidth: displayWidth,
-          maxWidth: displayWidth,
-          minHeight: displayHeight,
-          maxHeight: displayHeight,
+          minWidth: width,
+          maxWidth: width,
+          minHeight: height,
+          maxHeight: height,
         ),
         child: Stack(
           alignment: Alignment.center,
           children: [
             Image(image: image),
             CustomPaint(
-              size: Size(displayWidth, displayHeight),
+              size: Size(width, height),
               painter: ResultsPainter(),
             )
           ],

--- a/lib/menu_screen.dart
+++ b/lib/menu_screen.dart
@@ -54,6 +54,8 @@ class _MenuScreenState extends State<MenuScreen> {
       // run analysis only if both images have been uploaded
       print("Run Analysis");
       // code to run analysis
+      print(imageHandler.getImageDisplayHeight());
+      print(imageHandler.getImageDisplayWidth());
       Navigator.push(
           context, MaterialPageRoute(builder: (context) => ResultsScreen()));
     } else {

--- a/lib/menu_screen.dart
+++ b/lib/menu_screen.dart
@@ -35,7 +35,7 @@ class _MenuScreenState extends State<MenuScreen> {
 
   ImageProvider getFrontImageDisplay() {
     if (imageHandler.frontImagePath == null) {
-      return AssetImage("lib/images/image_placeholder.png");
+      return const AssetImage("lib/images/image_placeholder.png");
     } else {
       return FileImage(File(imageHandler.frontImagePath!));
     }
@@ -43,23 +43,44 @@ class _MenuScreenState extends State<MenuScreen> {
 
   ImageProvider getSideImageDisplay() {
     if (imageHandler.sideImagePath == null) {
-      return AssetImage("lib/images/image_placeholder.png");
+      return const AssetImage("lib/images/image_placeholder.png");
     } else {
       return FileImage(File(imageHandler.sideImagePath!));
     }
   }
 
-  void runAnalysis() {
+  void runAnalysis() async {
     if (!imageHandler.isMissingImages()) {
       // run analysis only if both images have been uploaded
       print("Run Analysis");
       // code to run analysis
       print(imageHandler.getImageDisplayHeight());
       print(imageHandler.getImageDisplayWidth());
+      await setImageRatio();
+      print("outside if");
       Navigator.push(
-          context, MaterialPageRoute(builder: (context) => ResultsScreen()));
+          context, MaterialPageRoute(builder: (context) => const ResultsScreen()));
     } else {
       _showNoImageAlert();
+    }
+  }
+
+  Future<void> setImageRatio() async {
+    print("setImageRatio");
+    if (!imageHandler.isSetImageToScreenRatio) {
+      print("inside if");
+      File imageFront = File(imageHandler.frontImagePath!);
+      var decodedImageFront = await decodeImageFromList(imageFront.readAsBytesSync());
+      imageHandler.setFrontImageScreenRatio(decodedImageFront.width.toDouble());
+
+      File imageLateral = File(imageHandler.sideImagePath!);
+      var decodedImageLateral = await decodeImageFromList(imageLateral.readAsBytesSync());
+      imageHandler.setLateralImageScreenRatio(decodedImageLateral.width.toDouble());
+
+      print(imageHandler.imageToScreenRatioFront);
+      print(imageHandler.imageToScreenRatioLateral);
+
+      imageHandler.isSetImageToScreenRatio = true;
     }
   }
 

--- a/lib/results_edit_screen.dart
+++ b/lib/results_edit_screen.dart
@@ -16,6 +16,34 @@ class ResultsEditScreen extends StatefulWidget {
 class _ResultsEditScreenState extends State<ResultsEditScreen> {
   ImageHandler imageHandler = ImageHandler();
 
+  // store temp values of the key points while they are edited in the drag screen.
+  late double tempFirstPointX;
+  late double tempFirstPointY;
+  late double tempSecondPointX;
+  late double tempSecondPointY;
+
+  void setTempPoints(double firstX, double firstY, double secondX, double secondY) {
+    tempFirstPointX = firstX;
+    tempFirstPointY = firstY;
+    tempSecondPointX = secondX;
+    tempSecondPointY = secondY;
+  }
+
+  // update the image handler with the currently stored and modified temp points
+  void updatePoints() {
+    if (imageHandler.isFrontImage) {
+      print("Updated Radial Styloid: $tempFirstPointX $tempFirstPointY");
+      print("Updated Min Articular Surface: $tempSecondPointX $tempSecondPointY");
+      imageHandler.setRadialStyloidFront(tempFirstPointX, tempFirstPointY);
+      imageHandler.setMinArticularSurface(tempSecondPointX, tempSecondPointY);
+    } else {
+      print("Updated Lateral Upper: $tempFirstPointX $tempFirstPointY");
+      print("Updated Lateral Lower: $tempSecondPointX $tempSecondPointY");
+      imageHandler.setlateralUpper(tempFirstPointX, tempFirstPointY);
+      imageHandler.setlateralLower(tempSecondPointX, tempSecondPointY);
+    }
+  }
+
   // whether or not the current image for analysis is Front/Side is updated in the Image Handler
   // you can get the image path via imageHandler.getCurrImagepath()
 
@@ -37,8 +65,10 @@ class _ResultsEditScreenState extends State<ResultsEditScreen> {
   }
 
   void confirmEdit() {
-    // save edited measurement poiunts and return to results screen
+    // update points in Image Handler and return to results screen
     print("Confirm Edit");
+    updatePoints();
+    Navigator.of(context).pop();
   }
 
   @override
@@ -73,7 +103,7 @@ class _ResultsEditScreenView extends StatelessWidget {
       decoration: BoxDecoration(
         border: Border.all(color: Colors.black),
       ),
-      child: DragScreen(passedImagePath: state.imageHandler.getCurrImagepath()!)
+      child: DragScreen(passedImagePath: state.imageHandler.getCurrImagepath()!, updateFunction: state.setTempPoints)
     );
   }
 

--- a/lib/results_screen.dart
+++ b/lib/results_screen.dart
@@ -38,8 +38,6 @@ class _ResultsScreenState extends State<ResultsScreen> {
   }
 
   void toImageResults(isFront) {
-    setImageRatio(isFront);
-
     imageHandler.isFrontImage = isFront;
 
     Navigator.push(
@@ -48,19 +46,6 @@ class _ResultsScreenState extends State<ResultsScreen> {
             builder: (context) => ImageResultsScreen(
                   isFrontImage: isFront,
                 ))).then((value) => setState(() {}));
-  }
-
-  void setImageRatio(isFront) async {
-    File image;
-    if (isFront) {
-      image = File(imageHandler.frontImagePath!);
-      var decodedImage = await decodeImageFromList(image.readAsBytesSync());
-      imageHandler.setFrontImageScreenRatio(decodedImage.width.toDouble());
-    } else {
-      image = File(imageHandler.sideImagePath!);
-      var decodedImage = await decodeImageFromList(image.readAsBytesSync());
-      imageHandler.setLateralImageScreenRatio(decodedImage.width.toDouble());
-    }
   }
 
   Widget getHeader() {

--- a/lib/results_screen.dart
+++ b/lib/results_screen.dart
@@ -38,13 +38,29 @@ class _ResultsScreenState extends State<ResultsScreen> {
   }
 
   void toImageResults(isFront) {
+    setImageRatio(isFront);
+
     imageHandler.isFrontImage = isFront;
+
     Navigator.push(
         context,
         MaterialPageRoute(
             builder: (context) => ImageResultsScreen(
                   isFrontImage: isFront,
-                )));
+                ))).then((value) => setState(() {}));
+  }
+
+  void setImageRatio(isFront) async {
+    File image;
+    if (isFront) {
+      image = File(imageHandler.frontImagePath!);
+      var decodedImage = await decodeImageFromList(image.readAsBytesSync());
+      imageHandler.setFrontImageScreenRatio(decodedImage.width.toDouble());
+    } else {
+      image = File(imageHandler.sideImagePath!);
+      var decodedImage = await decodeImageFromList(image.readAsBytesSync());
+      imageHandler.setLateralImageScreenRatio(decodedImage.width.toDouble());
+    }
   }
 
   Widget getHeader() {
@@ -86,9 +102,13 @@ class _ResultsScreenState extends State<ResultsScreen> {
   }
 
   Widget getResultsInfo() {
-    double volarTilt = 1.0;
+    double volarTilt = imageHandler.getVolarTilt();
     double radialHeight = imageHandler.getRadialHeight();
     double radialInclination = imageHandler.getRadialInclination();
+
+    print(volarTilt);
+    print(radialHeight);
+    print(radialInclination);
 
     return Container(
         margin: EdgeInsets.symmetric(vertical: 0.0, horizontal: 30.0),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -456,7 +456,7 @@ packages:
     source: hosted
     version: "1.3.1"
   vector_math:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: vector_math
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   path: ^1.8.2
   permission_handler: ^10.0.2
   image_pixels: ^3.0.0
+  vector_math: ^2.1.2
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
Added the ability to save edits made in the drag-and-drop screen, allowing the Image Handler to recalculate the updated measurements and display them on the results screen. 

Additionally, added the calculation of different scale ratios to convert between screen pixels, image pixels, and cm (IRL). This ratio is also used to calculate the correctly scaled radial height.

Also fixed a bug with the calculation of the angle measurements. The angles should be accurate now. 