### PR TITLE
delete images and reset variable values on Return Home from results screen

### DIFF
--- a/lib/image_handler.dart
+++ b/lib/image_handler.dart
@@ -57,6 +57,39 @@ class ImageHandler {
   
   ImageHandler._internal();
 
+  void reset() {
+    // delete image files
+    if (frontImagePath != null) {
+      File imageFile = File(frontImagePath!);
+      imageFile.deleteSync();
+    }
+    if (sideImagePath != null) {
+      File imageFile = File(sideImagePath!);
+      imageFile.deleteSync();
+    }
+
+    frontImagePath = null;
+    sideImagePath = null;
+
+    // screen/image/cm ratios and values
+    isSetImageToScreenRatio = false;
+    imageToScreenRatioFront = 1;
+    imageToScreenRatioLateral = 1;
+    screenToCmRatio = 1;
+    frontalLineLength = null;
+    frontalLineScreenLength = null;
+
+    // reset point values to defaults (probably not needed)
+    setRadialStyloidFront(200, 400);
+    setMinArticularSurface(400, 800);
+    setlateralUpper(300, 500);
+    setlateralLower(700, 700);
+
+    // not sure if this is needed, since this is set throughout the app
+    // as needed, but will just reset to original default value
+    isFrontImage = true;
+  }
+
   // only need set length scale for frontal image
   // set in image_confirm screen
   void setInputScale(double? lineLength, double? lineScreenLength) {

--- a/lib/results_screen.dart
+++ b/lib/results_screen.dart
@@ -27,6 +27,7 @@ class _ResultsScreenState extends State<ResultsScreen> {
   bool isScreenshotHandlerBuilding = false;
 
   void cancelResults() {
+    imageHandler.reset();
     Navigator.of(context).popUntil(ModalRoute.withName("welcome_screen"));
   }
 
@@ -224,6 +225,7 @@ class _ResultsScreenState extends State<ResultsScreen> {
     isScreenshotHandlerBuilding = isLoading;
     setState(() {});
   }
+
 //This returns all the widgets that are normally in the results screen
   Widget getResultsScreen() {
     return (Container(


### PR DESCRIPTION
all uploaded images are deleted, and image paths cleared.
all variables values (points, coords, and scale/rations) are reset to default values in Image Handler.